### PR TITLE
Add repository community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,31 @@
+name: Bug report
+description: Report reproducible behavior that is not working as expected
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to report a bug.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What happened, and what did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can it be reproduced?
+      description: Share a small example or a few steps if possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Anything else?
+      description: Add relevant logs, versions, or other context. Remove secrets first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Description
+
+<!--
+Describe the changes, why they were made, and their potential impact. Write a
+narrative rather than listing changed files or test instructions.
+-->
+
+## Related Issue
+
+Closes #
+
+<!-- Remove this section when there are no breaking or configuration changes. -->
+## Breaking or Configuration Changes
+
+> [!WARNING]
+> Describe any breaking or configuration changes and their impact.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+This is a personal open source project maintained by Tom Anderson. Everyone is
+welcome to participate, provided they treat others with respect.
+
+## Expected Behavior
+
+- Be considerate and constructive.
+- Respect different experiences, viewpoints, and levels of expertise.
+- Keep discussions focused on the project and its technical merits.
+- Accept feedback gracefully and give it with the goal of improving the work.
+- Take responsibility for mistakes and correct them when possible.
+
+## Unacceptable Behavior
+
+- Harassment, threats, intimidation, or discrimination
+- Personal attacks, insults, trolling, or deliberately inflammatory comments
+- Sexualized language, imagery, or unwanted attention
+- Publishing someone's private information without permission
+- Repeatedly disrupting project discussions or ignoring reasonable requests to
+  stop
+
+## Scope
+
+This Code of Conduct applies to this repository and its related project spaces,
+including issues, pull requests, discussions, and other project communication.
+
+## Project Boundaries
+
+This personal project does not provide private incident reporting or community
+moderation. Use GitHub's reporting and blocking tools for conduct that violates
+GitHub's policies.
+
+Tom may remove content, close issues or pull requests, or block participation
+when necessary to keep the repository focused and usable. This is repository
+maintenance, not a broader dispute-resolution service.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][covenant],
+version 2.1.
+
+[covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Thank you for considering a contribution to Bootstrap.
+
+## Before You Start
+
+- Search existing issues and pull requests before opening a new one.
+- Open an issue for substantial changes so the approach can be discussed first.
+- Keep changes focused and avoid unrelated refactoring.
+
+## Development
+
+Bootstrap requires Go 1.26 or later.
+
+Install [`goimports`](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) and
+[`golangci-lint` v2](https://golangci-lint.run/docs/welcome/install/) before
+submitting changes.
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes and add tests where appropriate.
+3. Format and verify the code:
+
+   ```bash
+   goimports -w .
+   golangci-lint run
+   go test ./...
+   ```
+
+4. Update documentation when behavior or public APIs change.
+5. Open a pull request describing the problem, the solution, and how it was
+   tested.
+
+## Reporting Bugs
+
+Include the Go version, operating system, relevant configuration, steps to
+reproduce the problem, expected behavior, and actual behavior. Remove secrets
+and other sensitive information from logs and examples.
+
+## Code of Conduct
+
+All contributors must follow the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tom Anderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # Bootstrap
 
+[![CI](https://github.com/renevo/bootstrap/actions/workflows/ci.yaml/badge.svg)](https://github.com/renevo/bootstrap/actions/workflows/ci.yaml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/renevo/bootstrap.svg)](https://pkg.go.dev/github.com/renevo/bootstrap)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/renevo/bootstrap?logo=go)](go.mod)
+[![License](https://img.shields.io/github/license/renevo/bootstrap)](LICENSE)
+
 Bootstrap assembles and runs an HTTP application with structured logging,
 configuration, OpenTelemetry, optional NATS connectivity, and static file
 serving. It requires Go 1.26 or later.
+
+> [!WARNING]
+> Bootstrap is pre-release software until version 1.0. APIs and behavior may
+> change without notice. Use it at your own risk, both before and after 1.0.
 
 ## Usage
 


### PR DESCRIPTION
This establishes the baseline policies and contribution workflow for the project. It documents how contributions are handled, sets practical conduct boundaries for a personally maintained repository, and applies the MIT license under Tom Anderson.

The repository presentation now includes standard Go project badges and a prominent prerelease notice. Lightweight bug reporting remains available alongside blank issues, while pull requests are guided toward narrative descriptions that explain context, reasoning, and impact.

> [!WARNING]
> Contributors are now expected to use `goimports` and `golangci-lint` v2. Bootstrap is explicitly documented as prerelease software until version 1.0 and remains use-at-your-own-risk after 1.0.