### PR TITLE
Add route-aware HTTP telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,17 @@ uppercase setting path with separators replaced by underscores, such as
 ## HTTP
 
 The HTTP server listens on `:8080` by default. It includes request logging,
-panic recovery, proxy-header handling, and OpenTelemetry tracing. It also
-exposes these built-in endpoints:
+panic recovery, proxy-header handling, and OpenTelemetry tracing and metrics.
+Route templates are used for span names and the `http.route` metric dimension,
+so route parameters do not create unbounded telemetry. Static file requests use
+the synthetic `StaticFile` route. Not-found spans are named `{METHOD} 404`,
+while method-not-allowed requests retain the matched route template.
+
+When present, Cloudflare tunnel headers are added to spans as
+`cloudflare.tunnel.ray`, `cloudflare.tunnel.ipcountry`,
+`cloudflare.tunnel.connecting_ip`, and `cloudflare.tunnel.warp_tag_id`.
+
+The server also exposes these built-in endpoints:
 
 | Path | Description |
 | --- | --- |
@@ -121,8 +130,10 @@ Token, NKEY, and credentials-file authentication can be configured; use
 ## OpenTelemetry
 
 The OpenTelemetry module always installs a Prometheus metrics exporter used by
-the `/metrics` endpoint. Set `otel.grpc.address` or `OTEL_GRPC_ADDRESS` to
-export traces to an OTLP gRPC collector. The collector connection currently
-uses insecure transport credentials, so deploy it only across a trusted or
-separately secured connection.
+the `/metrics` endpoint. HTTP instrumentation emits standard server request
+duration, request body size, and response body size metrics. Set
+`otel.grpc.address` or `OTEL_GRPC_ADDRESS` to export traces to an OTLP gRPC
+collector. The collector connection currently uses insecure transport
+credentials, so deploy it only across a trusted or separately secured
+connection.
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/renevo/application v0.6.0
 	github.com/renevo/config v0.6.0
 	github.com/renevo/ioc v1.1.0
-	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.69.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
@@ -22,6 +22,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	google.golang.org/grpc v1.82.0
 )
 
@@ -50,7 +51,6 @@ require (
 	github.com/zclconf/go-cty v1.19.0 // indirect
 	github.com/zclconf/go-cty-yaml v1.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/zclconf/go-cty-yaml v1.2.0 h1:GDyL4+e/Qe/S0B7YaecMLbVvAR/Mp21CXMOSiCT
 github.com/zclconf/go-cty-yaml v1.2.0/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
-go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.69.0 h1:dwsg8QoGoHdQB3fN9ReW//YL603X3kFTIV70N7i4fdw=
-go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.69.0/go.mod h1:JkN9Lf9q/KIPVUo+s/C7tBOQBaLRoXBwLR0M0DJwIm0=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 h1:4YsVu3B8+3qtWYYrsUYgn0OG78pN0rnNPRGX4SbokQI=
@@ -95,8 +95,6 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 h1:qazEJ
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0/go.mod h1:fOD2Yefuxixkx3ahVNf0O/PERb6r4OlbxfATVnYvzCo=
 go.opentelemetry.io/otel/exporters/prometheus v0.66.0 h1:vkrK8PAznv2NKt2r+kdu252ccGzkEqLc2aSXbQIALYQ=
 go.opentelemetry.io/otel/exporters/prometheus v0.66.0/go.mod h1:V/UB6D3vMF/UBOL5igAsAYnk1nG/bzYYTzvsB16cy7o=
-go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0 h1:bl2S7Ubua0Nms+D/gAmznQTd4dxxMA93aKbcpKqiTCs=
-go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0/go.mod h1:L0hRV50XdVIODHUfWEqGRCXQvj2rV82STVo12FMFBU0=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=

--- a/modules/http/module.go
+++ b/modules/http/module.go
@@ -142,7 +142,7 @@ func (m *module) Start(ctx *application.Context) error {
 
 	// static file hosting
 	if m.content != nil {
-		telemetry.staticRoute = router.PathPrefix("/").Handler(http.FileServer(m.content))
+		telemetry.staticRoute = router.PathPrefix("/").Handler(http.FileServer(m.content)).Methods(http.MethodGet, http.MethodHead)
 	}
 	if err := telemetry.configureFallbackHandlers(router); err != nil {
 		return fmt.Errorf("failed to configure HTTP telemetry: %w", err)

--- a/modules/http/module.go
+++ b/modules/http/module.go
@@ -1,6 +1,6 @@
 // Package http provides an application module backed by a Gorilla Mux HTTP
-// server. It includes request logging, panic recovery, OpenTelemetry tracing,
-// health and Prometheus endpoints, and optional static file serving.
+// server. It includes request logging, panic recovery, OpenTelemetry tracing and
+// metrics, health and Prometheus endpoints, and optional static file serving.
 package http
 
 import (
@@ -18,7 +18,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/renevo/application"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 type module struct {
@@ -78,6 +78,7 @@ func (m *module) Start(ctx *application.Context) error {
 	serverVersion := app.Version()
 
 	router := mux.NewRouter()
+	telemetry := newTelemetry()
 
 	// setup http server
 	m.server = &http.Server{
@@ -87,7 +88,11 @@ func (m *module) Start(ctx *application.Context) error {
 		BaseContext: func(net.Listener) context.Context {
 			return ctx
 		},
-		Handler: handlers.CombinedLoggingHandler(os.Stderr, handlers.ProxyHeaders(router)),
+		Handler: handlers.CombinedLoggingHandler(os.Stderr, handlers.ProxyHeaders(
+			otelhttp.NewHandler(telemetry.handler(router), app.Name(), otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+				return r.Method
+			})),
+		)),
 	}
 
 	// panic handling
@@ -101,21 +106,14 @@ func (m *module) Start(ctx *application.Context) error {
 		})
 	})
 
-	// tracing
-	// TODO: add cloud flare headers as span attributes
-	// Cf-Ray (ID)
-	// Cf-Ipcountry
-	// Cf-Connecting-Ip
-	// Cf-Warp-Tag-Id
-	router.Use(otelmux.Middleware(app.Name()))
+	// Route telemetry runs after mux selects a route and before application
+	// middleware, while the outer otelhttp handler captures every response.
+	router.Use(telemetry.middleware)
 
 	// TODO: These routes might need to be protected on specific addresses/ranges only
 	// for now, they are open to the world, which might not be a great idea
 
 	// prometheus metrics endpoint
-	// TODO: Need metrics for mux as the otel gorilla mux doesn't do metrics :/
-	// -     I did check a few implementations, and they don't seem to handle all of the cases for the response writer when gathering metrics
-	// -     The http snooper is a better option than all of these rando statswriter http.ResponseWriter iemplmentations
 	router.Handle("/metrics", promhttp.Handler())
 
 	// health check endpoint
@@ -144,7 +142,10 @@ func (m *module) Start(ctx *application.Context) error {
 
 	// static file hosting
 	if m.content != nil {
-		router.PathPrefix("/").Handler(http.FileServer(m.content))
+		telemetry.staticRoute = router.PathPrefix("/").Handler(http.FileServer(m.content))
+	}
+	if err := telemetry.configureFallbackHandlers(router); err != nil {
+		return fmt.Errorf("failed to configure HTTP telemetry: %w", err)
 	}
 
 	return nil

--- a/modules/http/telemetry.go
+++ b/modules/http/telemetry.go
@@ -1,0 +1,129 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type telemetry struct {
+	staticRoute    *mux.Route
+	allowedMethods []string
+}
+
+var cloudflareHeaders = map[string]attribute.Key{
+	"Cf-Ray":           "cloudflare.tunnel.ray",
+	"Cf-Ipcountry":     "cloudflare.tunnel.ipcountry",
+	"Cf-Connecting-Ip": "cloudflare.tunnel.connecting_ip",
+	"Cf-Warp-Tag-Id":   "cloudflare.tunnel.warp_tag_id",
+}
+
+func newTelemetry() *telemetry {
+	return &telemetry{}
+}
+
+func (t *telemetry) handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		span := trace.SpanFromContext(r.Context())
+		for header, key := range cloudflareHeaders {
+			if values := r.Header.Values(header); len(values) > 0 {
+				span.SetAttributes(key.StringSlice(values))
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (t *telemetry) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.enrichRoute(r, mux.CurrentRoute(r))
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (t *telemetry) configureFallbackHandlers(router *mux.Router) error {
+	methods := make(map[string]struct{})
+	if err := router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		routeMethods, err := route.GetMethods()
+		if err != nil {
+			return nil
+		}
+		for _, method := range routeMethods {
+			if _, exists := methods[method]; !exists {
+				methods[method] = struct{}{}
+				t.allowedMethods = append(t.allowedMethods, method)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	notFoundHandler := router.NotFoundHandler
+	if notFoundHandler == nil {
+		notFoundHandler = http.NotFoundHandler()
+	}
+	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		trace.SpanFromContext(r.Context()).SetName(r.Method + " 404")
+		notFoundHandler.ServeHTTP(w, r)
+	})
+
+	methodNotAllowedHandler := router.MethodNotAllowedHandler
+	if methodNotAllowedHandler == nil {
+		methodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		})
+	}
+	router.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.enrichRoute(r, t.methodNotAllowedRoute(router, r))
+		methodNotAllowedHandler.ServeHTTP(w, r)
+	})
+
+	return nil
+}
+
+func (t *telemetry) methodNotAllowedRoute(router *mux.Router, r *http.Request) *mux.Route {
+	for _, method := range t.allowedMethods {
+		if method == r.Method {
+			continue
+		}
+
+		// A 405 has no CurrentRoute, so retry matching with registered methods
+		// to recover the route template without executing its handler chain.
+		probe := r.Clone(r.Context())
+		probe.Method = method
+		var match mux.RouteMatch
+		if router.Match(probe, &match) && match.MatchErr == nil && match.Route != nil {
+			return match.Route
+		}
+	}
+	return nil
+}
+
+func (t *telemetry) enrichRoute(r *http.Request, route *mux.Route) {
+	if route == nil {
+		return
+	}
+
+	routeName := ""
+	if route == t.staticRoute {
+		routeName = "StaticFile"
+	} else if template, err := route.GetPathTemplate(); err == nil {
+		routeName = template
+	}
+	if routeName == "" {
+		return
+	}
+
+	span := trace.SpanFromContext(r.Context())
+	span.SetName(r.Method + " " + routeName)
+	span.SetAttributes(attribute.String("http.route", routeName))
+
+	if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+		labeler.Add(attribute.String("http.route", routeName))
+	}
+}

--- a/modules/http/telemetry_test.go
+++ b/modules/http/telemetry_test.go
@@ -1,0 +1,315 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gorilla/mux"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestTelemetryRouteTemplate(t *testing.T) {
+	handler, recorder, reader := newTelemetryTestHandler(t, func(router *mux.Router, _ *telemetry) {
+		router.HandleFunc("/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}).Methods(http.MethodGet)
+	})
+
+	for _, path := range []string{"/users/one", "/users/two"} {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code != http.StatusNoContent {
+			t.Fatalf("%s returned %d, want %d", path, response.Code, http.StatusNoContent)
+		}
+	}
+
+	spans := recorder.Ended()
+	if len(spans) != 2 {
+		t.Fatalf("got %d spans, want 2", len(spans))
+	}
+	for _, span := range spans {
+		assertSpanRoute(t, span, "GET /users/{id}", "/users/{id}")
+	}
+	if count := metricRouteCount(t, reader, "/users/{id}"); count != 2 {
+		t.Errorf("route metric count = %d, want 2", count)
+	}
+}
+
+func TestTelemetryStaticFile(t *testing.T) {
+	handler, recorder, reader := newTelemetryTestHandler(t, func(router *mux.Router, telemetry *telemetry) {
+		content := http.FS(fstest.MapFS{
+			"one.txt": {Data: []byte("one")},
+			"two.txt": {Data: []byte("two")},
+		})
+		telemetry.staticRoute = router.PathPrefix("/").Handler(http.FileServer(content))
+	})
+
+	for _, path := range []string{"/one.txt", "/two.txt"} {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code != http.StatusOK {
+			t.Fatalf("%s returned %d, want %d", path, response.Code, http.StatusOK)
+		}
+	}
+
+	spans := recorder.Ended()
+	if len(spans) != 2 {
+		t.Fatalf("got %d spans, want 2", len(spans))
+	}
+	for _, span := range spans {
+		assertSpanRoute(t, span, "GET StaticFile", "StaticFile")
+	}
+	if count := metricRouteCount(t, reader, "StaticFile"); count != 2 {
+		t.Errorf("static file metric count = %d, want 2", count)
+	}
+}
+
+func TestTelemetryNotFoundHandler(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		custom bool
+	}{
+		{name: "default"},
+		{name: "custom", custom: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			customCalled := false
+			handler, recorder, _ := newTelemetryTestHandler(t, func(router *mux.Router, _ *telemetry) {
+				if test.custom {
+					router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						customCalled = true
+						w.WriteHeader(http.StatusNotFound)
+					})
+				}
+			})
+
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/missing", nil))
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusNotFound)
+			}
+			if customCalled != test.custom {
+				t.Errorf("custom handler called = %t, want %t", customCalled, test.custom)
+			}
+
+			span := onlyEndedSpan(t, recorder)
+			if span.Name() != "GET 404" {
+				t.Errorf("span name = %q, want %q", span.Name(), "GET 404")
+			}
+			if _, ok := spanAttribute(span, "http.route"); ok {
+				t.Error("404 span unexpectedly has http.route")
+			}
+		})
+	}
+}
+
+func TestTelemetryMethodNotAllowedHandler(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		custom bool
+	}{
+		{name: "default"},
+		{name: "custom", custom: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			customCalled := false
+			handler, recorder, reader := newTelemetryTestHandler(t, func(router *mux.Router, _ *telemetry) {
+				router.HandleFunc("/users/{id}", func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusNoContent)
+				}).Methods(http.MethodGet)
+				if test.custom {
+					router.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						customCalled = true
+						w.WriteHeader(http.StatusMethodNotAllowed)
+					})
+				}
+			})
+
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/users/one", nil))
+			if response.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
+			}
+			if customCalled != test.custom {
+				t.Errorf("custom handler called = %t, want %t", customCalled, test.custom)
+			}
+
+			assertSpanRoute(t, onlyEndedSpan(t, recorder), "POST /users/{id}", "/users/{id}")
+			if count := metricRouteCount(t, reader, "/users/{id}"); count != 1 {
+				t.Errorf("route metric count = %d, want 1", count)
+			}
+		})
+	}
+}
+
+func TestTelemetryHandlerCloudflareHeaders(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
+
+	request := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	request.Header.Add("Cf-Ray", "ray-one")
+	request.Header.Add("Cf-Ray", "ray-two")
+	request.Header.Set("Cf-Ipcountry", "US")
+	request.Header.Set("Cf-Connecting-Ip", "203.0.113.10")
+	request.Header.Set("Cf-Warp-Tag-Id", "warp-tag")
+
+	telemetry := newTelemetry()
+	handler := otelhttp.NewHandler(
+		telemetry.handler(http.NotFoundHandler()),
+		"test",
+		otelhttp.WithTracerProvider(provider),
+	)
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+
+	attributes := make(map[attribute.Key]attribute.Value)
+	for _, attr := range spans[0].Attributes() {
+		attributes[attr.Key] = attr.Value
+	}
+
+	want := map[attribute.Key][]string{
+		"cloudflare.tunnel.ray":           {"ray-one", "ray-two"},
+		"cloudflare.tunnel.ipcountry":     {"US"},
+		"cloudflare.tunnel.connecting_ip": {"203.0.113.10"},
+		"cloudflare.tunnel.warp_tag_id":   {"warp-tag"},
+	}
+	for key, values := range want {
+		got, ok := attributes[key]
+		if !ok {
+			t.Errorf("missing span attribute %q", key)
+			continue
+		}
+		if got.Type() != attribute.STRINGSLICE || !slices.Equal(got.AsStringSlice(), values) {
+			t.Errorf("attribute %q = %v, want %v", key, got.AsInterface(), values)
+		}
+	}
+}
+
+func TestTelemetryHandlerOmitsMissingCloudflareHeaders(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
+
+	telemetry := newTelemetry()
+	handler := otelhttp.NewHandler(
+		telemetry.handler(http.NotFoundHandler()),
+		"test",
+		otelhttp.WithTracerProvider(provider),
+	)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/missing", nil))
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+
+	for _, attr := range spans[0].Attributes() {
+		for _, key := range cloudflareHeaders {
+			if attr.Key == key {
+				t.Errorf("unexpected empty Cloudflare attribute %q", attr.Key)
+			}
+		}
+	}
+}
+
+func newTelemetryTestHandler(
+	t *testing.T,
+	setup func(*mux.Router, *telemetry),
+) (http.Handler, *tracetest.SpanRecorder, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	telemetry := newTelemetry()
+	router := mux.NewRouter()
+	router.Use(telemetry.middleware)
+	setup(router, telemetry)
+	if err := telemetry.configureFallbackHandlers(router); err != nil {
+		t.Fatalf("configure fallback handlers: %v", err)
+	}
+
+	spanRecorder := tracetest.NewSpanRecorder()
+	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() { _ = traceProvider.Shutdown(t.Context()) })
+
+	metricReader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(metricReader))
+	t.Cleanup(func() { _ = meterProvider.Shutdown(t.Context()) })
+
+	handler := otelhttp.NewHandler(
+		telemetry.handler(router),
+		"test",
+		otelhttp.WithTracerProvider(traceProvider),
+		otelhttp.WithMeterProvider(meterProvider),
+		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+			return r.Method
+		}),
+	)
+	return handler, spanRecorder, metricReader
+}
+
+func onlyEndedSpan(t *testing.T, recorder *tracetest.SpanRecorder) sdktrace.ReadOnlySpan {
+	t.Helper()
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	return spans[0]
+}
+
+func assertSpanRoute(t *testing.T, span sdktrace.ReadOnlySpan, name, route string) {
+	t.Helper()
+	if span.Name() != name {
+		t.Errorf("span name = %q, want %q", span.Name(), name)
+	}
+	value, ok := spanAttribute(span, "http.route")
+	if !ok || value.AsString() != route {
+		t.Errorf("http.route = %v, want %q", value.AsInterface(), route)
+	}
+}
+
+func spanAttribute(span sdktrace.ReadOnlySpan, key attribute.Key) (attribute.Value, bool) {
+	for _, attr := range span.Attributes() {
+		if attr.Key == key {
+			return attr.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+func metricRouteCount(t *testing.T, reader *sdkmetric.ManualReader, route string) uint64 {
+	t.Helper()
+	var metrics metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &metrics); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	for _, scope := range metrics.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != "http.server.request.duration" {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("request duration has type %T, want histogram", metric.Data)
+			}
+			for _, point := range histogram.DataPoints {
+				value, ok := point.Attributes.Value("http.route")
+				if ok && value.AsString() == route {
+					return point.Count
+				}
+			}
+		}
+	}
+	return 0
+}

--- a/modules/http/telemetry_test.go
+++ b/modules/http/telemetry_test.go
@@ -49,7 +49,7 @@ func TestTelemetryStaticFile(t *testing.T) {
 			"one.txt": {Data: []byte("one")},
 			"two.txt": {Data: []byte("two")},
 		})
-		telemetry.staticRoute = router.PathPrefix("/").Handler(http.FileServer(content))
+		telemetry.staticRoute = router.PathPrefix("/").Handler(http.FileServer(content)).Methods(http.MethodGet, http.MethodHead)
 	})
 
 	for _, path := range []string{"/one.txt", "/two.txt"} {
@@ -69,6 +69,24 @@ func TestTelemetryStaticFile(t *testing.T) {
 	}
 	if count := metricRouteCount(t, reader, "StaticFile"); count != 2 {
 		t.Errorf("static file metric count = %d, want 2", count)
+	}
+}
+
+func TestTelemetryStaticFileMethodNotAllowed(t *testing.T) {
+	handler, recorder, reader := newTelemetryTestHandler(t, func(router *mux.Router, telemetry *telemetry) {
+		content := http.FS(fstest.MapFS{"one.txt": {Data: []byte("one")}})
+		telemetry.staticRoute = router.PathPrefix("/").Handler(http.FileServer(content)).Methods(http.MethodGet, http.MethodHead)
+	})
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/one.txt", nil))
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
+	}
+
+	assertSpanRoute(t, onlyEndedSpan(t, recorder), "POST StaticFile", "StaticFile")
+	if count := metricRouteCount(t, reader, "StaticFile"); count != 1 {
+		t.Errorf("static file metric count = %d, want 1", count)
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces the Gorilla mux-specific tracing middleware with `otelhttp`, adding standard OpenTelemetry HTTP server metrics while retaining trace propagation and response capture across the entire request lifecycle.

Matched requests use Gorilla route templates for span names and the `http.route` dimension, preventing concrete route parameters from creating unbounded telemetry. Static content is grouped under the synthetic `StaticFile` route and is explicitly limited to `GET` and `HEAD`; rejected methods return 405 while retaining the same bounded telemetry route. True not-found requests receive bounded `{METHOD} 404` span names without a fabricated route. Method-not-allowed requests recover the method-independent route template so their spans and metrics remain grouped with successful requests to the same route. Existing custom not-found and method-not-allowed handlers continue to control their responses.

Cloudflare tunnel request metadata is attached to spans under the `cloudflare.tunnel` namespace when the corresponding headers are present. Missing headers are omitted, and these values are not added to metric dimensions.

The HTTP documentation describes the emitted server metrics, route naming behavior, fallback handling, static-content aggregation, and Cloudflare attributes. This change does not alter public APIs or require configuration changes.

Closes #10